### PR TITLE
CICD-2: Failure to find the package

### DIFF
--- a/inventories/bare_metal/group_vars/all/base_packages.yml
+++ b/inventories/bare_metal/group_vars/all/base_packages.yml
@@ -3,7 +3,7 @@ base_packages:
   - name: "strace"
   - name: "vim"  
   - name: "lsof"
-  - name: "nc"
+  - name: "netcat"
   - name: "nload"
   - name: "telnet"
   - name: "chrony"


### PR DESCRIPTION
```
failed: [vmhost01] (item={u'name': u'nc'}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "nc"}, "msg": "No package matching 'nc' is available"}
```