### PR TITLE
/NOJIRA: Make sure the file is overwritten

### DIFF
--- a/roles/services/emby/tasks/config-emby.yml
+++ b/roles/services/emby/tasks/config-emby.yml
@@ -7,7 +7,7 @@
     hour: "0"
     job: "cd /var/lib/emby; \
       wget {{ epg_data.url }}{{ epg_data.filename }} ;\
-        gunzip {{ epg_data.filename }} ;\
+        gunzip -f {{ epg_data.filename }} ;\
         chown emby:emby  {{ epg_data.filename }} ;\
         chmod 400 {{ epg_data.filename }}"
   when: epg_data_gather

--- a/roles/services/emby/tasks/config-emby.yml
+++ b/roles/services/emby/tasks/config-emby.yml
@@ -6,8 +6,8 @@
     minute: "0"
     hour: "0"
     job: "cd /var/lib/emby; \
-      wget {{ epg_data.url }}{{ epg_data.filename }} ;\
-        gunzip -f {{ epg_data.filename }} ;\
+      wget {{ epg_data.url }}{{ epg_data.filename }}.gz ;\
+        gunzip -f {{ epg_data.filename }}.gz ;\
         chown emby:emby  {{ epg_data.filename }} ;\
         chmod 400 {{ epg_data.filename }}"
   when: epg_data_gather


### PR DESCRIPTION
This doesn't need a JIRA. What happens is we get the file downloaded but the `gunzip` fails as the previous week's file is still around. That means we need to force the new one to overwrite the previous one. 

The second that we change in the this PR is that we expect the filename to be essentially an `xml` epg file, and the `gz` suffix is incidental and should not be part of the variable (filename) 

MM