### PR TITLE
Feature/CICD-103: install grafana on ubuntu26

### DIFF
--- a/roles/base/common/vars/main.yml
+++ b/roles/base/common/vars/main.yml
@@ -3,7 +3,7 @@ base_common_base_packages:
   - 'strace'
   - 'vim'
   - 'lsof'
-  - 'netcat'
+  - 'nmap'
   - 'nload'
   - 'telnet'
   - 'chrony'

--- a/roles/services/grafana/tasks/install-grafana.yml
+++ b/roles/services/grafana/tasks/install-grafana.yml
@@ -1,14 +1,16 @@
 ---
-- name: 'Install-grafana: Import GPG key'
-  ansible.builtin.apt_key:
-    url: "https://apt.grafana.com/gpg.key"
+- name: 'Install-grafana: Add Grafana APT repository'
+  ansible.builtin.deb822_repository:
+    name: 'grafana'
+    types:
+      - 'deb'
+    uris: 'https://apt.grafana.com'
+    suites:
+      - 'stable'
+    components:
+      - 'main'
+    signed_by: 'https://apt.grafana.com/gpg-full.key'
     state: 'present'
-
-- name: 'Install-grafana: Add grafana repository'
-  ansible.builtin.apt_repository:
-    repo: 'deb https://apt.grafana.com stable main'
-    state: 'present'
-    update_cache: true
 
 - name: 'Install-grafana: Install grafana'
   ansible.builtin.package:


### PR DESCRIPTION
I need to merge this, i don't have ansible > 2.15 to try this module. This needs to go through CICD. 
I mean, grafana may still not be installed. 